### PR TITLE
feat: add safari support

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,8 @@ There are three ways to make cookies available to `leetgo`:
 
 - Read cookies from browser automatically.
   
-  Currently, `leetgo` supports Chrome, FireFox, and Safari*.
+  Currently, `leetgo` supports Chrome, FireFox, and Safari[^1].
   If you want to support other browsers, please let us know!
-
-  *For Safari on MacOS, you may need to grant `Full Disk Access` privilege to your terminal app which you would like to run `leetgo`.
 
   ```yaml
   leetcode:
@@ -352,3 +350,5 @@ Here are some awesome projects that inspired me to create this project:
 - https://github.com/clearloop/leetcode-cli
 - https://github.com/budougumi0617/leetgode
 - https://github.com/skygragon/leetcode-cli
+
+[^1] For Safari on MacOS, you may need to grant `Full Disk Access` privilege to your terminal app which you would like to run `leetgo`.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,10 @@ There are three ways to make cookies available to `leetgo`:
 
 - Read cookies from browser automatically.
   
-  Currently, Chrome and FireFox are supported, if you want to support other browsers, please let us know!
+  Currently, `leetgo` supports Chrome, FireFox, and Safari*.
+  If you want to support other browsers, please let us know!
+
+  *For Safari on MacOS, you may need to grant `Full Disk Access` privilege to your terminal app which you would like to run `leetgo`.
 
   ```yaml
   leetcode:

--- a/README.md
+++ b/README.md
@@ -351,4 +351,4 @@ Here are some awesome projects that inspired me to create this project:
 - https://github.com/budougumi0617/leetgode
 - https://github.com/skygragon/leetcode-cli
 
-[^1] For Safari on MacOS, you may need to grant `Full Disk Access` privilege to your terminal app which you would like to run `leetgo`.
+[^1]: For Safari on MacOS, you may need to grant `Full Disk Access` privilege to your terminal app which you would like to run `leetgo`.

--- a/README_zh.md
+++ b/README_zh.md
@@ -233,7 +233,9 @@ editor:
 
 - 从浏览器中直接读取。
   
-  这是最方便的方法，也是默认的行为。目前支持 Chrome 和 FireFox，如果你需要其他浏览器的支持，请告诉我们~
+  这是最方便的方法，也是默认的行为。目前支持 Chrome，FireFox 和 Safari[^1]。
+
+  如果你需要其他浏览器的支持，请告诉我们~
 
   ```yaml
   leetcode:
@@ -344,3 +346,5 @@ Debug 模式下 `leetgo` 会输出详细的日志，请复制这些日志，并�
 - https://github.com/clearloop/leetcode-cli
 - https://github.com/budougumi0617/leetgode
 - https://github.com/skygragon/leetcode-cli
+
+[^1]: 使用 Safari 的用户注意，你需要赋予使用 `leetgo` 的终端 App `全盘访问`的权限。

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/zellyn/kooky => github.com/j178/kooky v0.0.0-20230105140252-602b62fe3a37
+replace github.com/zellyn/kooky => github.com/j178/kooky v0.0.0-20230203021902-e439c6617a99
 
 require (
 	github.com/alessio/shellescape v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ivanpirog/coloredcobra v1.0.1 h1:aURSdEmlR90/tSiWS0dMjdwOvCVUeYLfltLfbgNxrN4=
 github.com/ivanpirog/coloredcobra v1.0.1/go.mod h1:iho4nEKcnwZFiniGSdcgdvRgZNjxm+h20acv8vqmN6Q=
-github.com/j178/kooky v0.0.0-20230105140252-602b62fe3a37 h1:0Jubdyhw34xefyQNimXsfhPe1nwqYMYmLp83UyI1/NA=
-github.com/j178/kooky v0.0.0-20230105140252-602b62fe3a37/go.mod h1:1HwdQrib6jLeThohjFWjBnZbsuPekrRlHi43dL1ZmB8=
+github.com/j178/kooky v0.0.0-20230203021902-e439c6617a99 h1:GpAZUZcPT0KqjfO1tBcrHAi5bbrE5e+/zylIxVXMo28=
+github.com/j178/kooky v0.0.0-20230203021902-e439c6617a99/go.mod h1:1HwdQrib6jLeThohjFWjBnZbsuPekrRlHi43dL1ZmB8=
 github.com/jedib0t/go-pretty/v6 v6.4.4 h1:N+gz6UngBPF4M288kiMURPHELDMIhF/Em35aYuKrsSc=
 github.com/jedib0t/go-pretty/v6 v6.4.4/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/leetcode/credential.go
+++ b/leetcode/credential.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zellyn/kooky"
 	_ "github.com/zellyn/kooky/browser/chrome"
 	_ "github.com/zellyn/kooky/browser/firefox"
+	_ "github.com/zellyn/kooky/browser/safari"
 
 	"github.com/j178/leetgo/config"
 )


### PR DESCRIPTION
This is a Draft PR because it requires another dependency to merge [a Fix PR](https://github.com/zellyn/kooky/pull/58).

This PR is going to support safari linked to issue #74.

The `kooky` project got a bug in Ventura and we could not read the correct cookie file. I have created a Fix PR but not been merged yet.

But I found that this project is using @j178's fork version of `kooky`. I am wondering if you will sync the code from source `kooky`. If you don't sync the code from the source repo, I may need to create the same fix for your fork.

Besides, I only test the `leetgo whoami` command locally. And the README will be modified after the dependency is updated.