### PR TITLE
fix: handle error in sqlite cache

### DIFF
--- a/leetcode/cache_sqlite.go
+++ b/leetcode/cache_sqlite.go
@@ -93,8 +93,8 @@ func (c *sqliteCache) Outdated() bool {
 	if err != nil {
 		return true
 	}
-	st, e := db.Prepare("select timestamp from lastUpdate")
-	if e != nil {
+	st, err := db.Prepare("select timestamp from lastUpdate")
+	if err != nil {
 		return true
 	}
 	var ts int64

--- a/leetcode/cache_sqlite.go
+++ b/leetcode/cache_sqlite.go
@@ -93,7 +93,10 @@ func (c *sqliteCache) Outdated() bool {
 	if err != nil {
 		return true
 	}
-	st, _ := db.Prepare("select timestamp from lastUpdate")
+	st, e := db.Prepare("select timestamp from lastUpdate")
+	if e != nil {
+		return true
+	}
 	var ts int64
 	err = st.QueryRow().Scan(&ts)
 	if err != nil {


### PR DESCRIPTION
When trying to init for the first time, there will get panic cause the SQLite will be nil.

This PR is going to fix this bug.