### PR TITLE
feat: support `leetgo open`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Available Commands:
   contest                 Generate contest questions
   cache                   Manage local questions cache
   config                  Show configurations
+  open                    open a question in browser
   help                    Help about any command
 
 Flags:

--- a/README_zh.md
+++ b/README_zh.md
@@ -98,6 +98,7 @@ Available Commands:
   contest                 Generate contest questions
   cache                   Manage local questions cache
   config                  Show configurations
+  open                    open a question in browser
   help                    Help about any command
 
 Flags:

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/j178/leetgo/leetcode"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+
+	"github.com/j178/leetgo/leetcode"
 )
 
 var openCmd = &cobra.Command{
@@ -13,25 +14,23 @@ var openCmd = &cobra.Command{
 leetgo open today
 leetgo open 549
 leetgo open two-sum`,
-	Args: cobra.MaximumNArgs(1),
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cred := leetcode.CredentialsFromConfig()
 		c := leetcode.NewClient(leetcode.WithCredentials(cred))
-		var err error
-		if len(args) > 0 {
-			qid := args[0]
-			qs, err := leetcode.ParseQID(qid, c)
-			if err != nil {
-				return err
-			}
-			for i := 0; i < len(qs); i++ { // qs is 4 or 1
-				if qs[i].IsContest() {
-					err = browser.OpenURL(qs[i].ContestUrl())
-				} else {
-					err = browser.OpenURL(qs[i].Url())
-				}
+		qid := args[0]
+		qs, err := leetcode.ParseQID(qid, c)
+		if err != nil {
+			return err
+		}
+		for _, q := range qs { // qs is 4 or 1
+			if q.IsContest() {
+				err = browser.OpenURL(q.ContestUrl())
+			} else {
+				err = browser.OpenURL(q.Url())
 			}
 		}
+
 		return err
 	},
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -23,7 +23,7 @@ leetgo open two-sum`,
 		if err != nil {
 			return err
 		}
-		for _, q := range qs { // qs is 4 or 1
+		for _, q := range qs {
 			if q.IsContest() {
 				err = browser.OpenURL(q.ContestUrl())
 			} else {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/j178/leetgo/leetcode"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+var openCmd = &cobra.Command{
+	Use:   "open [qid]",
+	Short: "open a question in browser",
+	Example: `leetgo open
+leetgo open today
+leetgo open 549
+leetgo open two-sum`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cred := leetcode.CredentialsFromConfig()
+		c := leetcode.NewClient(leetcode.WithCredentials(cred))
+		var err error
+		if len(args) > 0 {
+			qid := args[0]
+			qs, err := leetcode.ParseQID(qid, c)
+			if err != nil {
+				return err
+			}
+			if len(qs) > 1 {
+				for _, r := range qs {
+					err = browser.OpenURL(r.ContestUrl())
+				}
+			} else {
+				err = browser.OpenURL(qs[0].Url())
+
+			}
+
+		}
+		return err
+	},
+}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -24,15 +24,13 @@ leetgo open two-sum`,
 			if err != nil {
 				return err
 			}
-			if len(qs) > 1 {
-				for _, r := range qs {
-					err = browser.OpenURL(r.ContestUrl())
+			for i := 0; i < len(qs); i++ { // qs is 4 or 1
+				if qs[i].IsContest() {
+					err = browser.OpenURL(qs[i].ContestUrl())
+				} else {
+					err = browser.OpenURL(qs[i].Url())
 				}
-			} else {
-				err = browser.OpenURL(qs[0].Url())
-
 			}
-
 		}
 		return err
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,6 +122,7 @@ func initCommands() {
 		gitCmd,
 		inspectCmd,
 		whoamiCmd,
+		openCmd,
 	}
 	for _, cmd := range commands {
 		cmd.Flags().SortFlags = false


### PR DESCRIPTION
### About
This PR is to support `leetgo open` feature. Closes #113 
Tested on Windows/amd64.

### How it works
I borrowed the implementation from `pick`, in which the `ParseQID` function has processed the parameters after `open`. It only needs to determine whether it is a contest based on the number of questions we get and open the corresponding page.
### Demo video here

https://user-images.githubusercontent.com/101162387/219935470-c2391514-40ab-4c28-a9d4-228abe9c62ca.mp4

