### PR TITLE
fix:  local Python test util type checking errors

### DIFF
--- a/testutils/python/pyproject.toml
+++ b/testutils/python/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "leetgo-py"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python test utils for leetgo"
 authors = ["j178 <10510431+j178@users.noreply.github.com>"]
 license = "MIT"

--- a/testutils/python/src/leetgo_py/parse.py
+++ b/testutils/python/src/leetgo_py/parse.py
@@ -15,14 +15,14 @@ def split_array(s: str) -> List[str]:
 
 
 def serialize(val: Any) -> str:
-    if isinstance(val, int):
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    elif isinstance(val, int):
         return str(val)
     elif isinstance(val, float):
         return str(val)
     elif isinstance(val, str):
         return '"' + val + '"'
-    elif isinstance(val, bool):
-        return "true" if val else "false"
     elif isinstance(val, list):
         return "[" + ",".join(serialize(v) for v in val) + "]"
     elif isinstance(val, (ListNode, TreeNode)):


### PR DESCRIPTION
Fix local Python test util serialize function type checking erros.

solution.py
```python
class Solution:
    def equalFrequency(self, word: str) -> bool:
        return False
```
When using the `leetgo test 2423 --lang python -L` for local testing, it will raise `Invalid output` erros.

The reason why any bools passed into the elif clauses will not make sense is that `isinstance(<bool>, int)` will always return`True`. Therefore, we need to check for bool before checking for int in if/elif statements.
