### PR TITLE
feat: allow variables in custom editor command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ code:
     out_dir: python
     # Overrides the default code.filename_template
     filename_template: ""
-    # Python executable to run the generated code
+    # Python executable that creates the venv
     executable: python3
   cpp:
     out_dir: cpp

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ editor:
   use: none
   # Custom command to open files
   command: ""
-  # Arguments to the command
+  # Arguments to the command.
+  # String contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}}, {{.AllFiles}} will be replaced with corresponding file path
   args: []
 ```
 <!-- END CONFIG -->

--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ editor:
   # Custom command to open files
   command: ""
   # Arguments to the command.
-  # String contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}}, {{.AllFiles}} will be replaced with corresponding file path
+  # String contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}} will be replaced with corresponding file path.
+  # {{.Files}} will be substituted with the list of all file paths.
   args: []
 ```
 <!-- END CONFIG -->

--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ code:
     - name: removeUselessComments
   go:
     out_dir: go
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
     # Functions that modify the generated code
     modifiers:
       - name: removeUselessComments
@@ -203,14 +201,10 @@ code:
       - name: addMod
   python3:
     out_dir: python
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
     # Python executable that creates the venv
     executable: python3
   cpp:
     out_dir: cpp
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
     # C++ compiler
     cxx: g++
     # C++ compiler flags (our Leetcode I/O library implementation requires C++17)
@@ -219,12 +213,8 @@ code:
       - -std=c++17
   rust:
     out_dir: rust
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
   java:
     out_dir: java
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
 # LeetCode configuration
 leetcode:
   # LeetCode site, https://leetcode.com or https://leetcode.cn

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ code:
     - name: removeUselessComments
   go:
     out_dir: go
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
     # Functions that modify the generated code
     modifiers:
@@ -203,13 +203,13 @@ code:
       - name: addMod
   python3:
     out_dir: python
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
     # Python executable that creates the venv
     executable: python3
   cpp:
     out_dir: cpp
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
     # C++ compiler
     cxx: g++
@@ -219,11 +219,11 @@ code:
       - -std=c++17
   rust:
     out_dir: rust
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
   java:
     out_dir: java
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
 # LeetCode configuration
 leetcode:

--- a/README_zh.md
+++ b/README_zh.md
@@ -187,7 +187,7 @@ code:
     - name: removeUselessComments
   go:
     out_dir: go
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
     # Functions that modify the generated code
     modifiers:
@@ -197,13 +197,13 @@ code:
       - name: addMod
   python3:
     out_dir: python
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
     # Python executable that creates the venv
     executable: python3
   cpp:
     out_dir: cpp
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
     # C++ compiler
     cxx: g++
@@ -213,11 +213,11 @@ code:
       - -std=c++17
   rust:
     out_dir: rust
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
   java:
     out_dir: java
-    # Overrides the default code.filename_template
+    # Overrides the default code.filename_template, empty will be ignored
     filename_template: ""
 # LeetCode configuration
 leetcode:

--- a/README_zh.md
+++ b/README_zh.md
@@ -187,8 +187,6 @@ code:
     - name: removeUselessComments
   go:
     out_dir: go
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
     # Functions that modify the generated code
     modifiers:
       - name: removeUselessComments
@@ -197,14 +195,10 @@ code:
       - name: addMod
   python3:
     out_dir: python
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
     # Python executable that creates the venv
     executable: python3
   cpp:
     out_dir: cpp
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
     # C++ compiler
     cxx: g++
     # C++ compiler flags (our Leetcode I/O library implementation requires C++17)
@@ -213,12 +207,8 @@ code:
       - -std=c++17
   rust:
     out_dir: rust
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
   java:
     out_dir: java
-    # Overrides the default code.filename_template, empty will be ignored
-    filename_template: ""
 # LeetCode configuration
 leetcode:
   # LeetCode site, https://leetcode.com or https://leetcode.cn

--- a/README_zh.md
+++ b/README_zh.md
@@ -249,7 +249,8 @@ editor:
   use: none
   # Custom command to open files
   command: ""
-  # Arguments to the command
+  # Arguments to the command.
+  # String contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}}, {{.AllFiles}} will be replaced with corresponding file path
   args: []
 ```
 <!-- END CONFIG -->

--- a/README_zh.md
+++ b/README_zh.md
@@ -250,7 +250,8 @@ editor:
   # Custom command to open files
   command: ""
   # Arguments to the command.
-  # String contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}}, {{.AllFiles}} will be replaced with corresponding file path
+  # String contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}} will be replaced with corresponding file path.
+  # {{.Files}} will be substituted with the list of all file paths.
   args: []
 ```
 <!-- END CONFIG -->

--- a/README_zh.md
+++ b/README_zh.md
@@ -199,7 +199,7 @@ code:
     out_dir: python
     # Overrides the default code.filename_template
     filename_template: ""
-    # Python executable to run the generated code
+    # Python executable that creates the venv
     executable: python3
   cpp:
     out_dir: cpp

--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ type CodeConfig struct {
 
 type BaseLangConfig struct {
 	OutDir                  string     `yaml:"out_dir" mapstructure:"out_dir"`
-	FilenameTemplate        string     `yaml:"filename_template" mapstructure:"filename_template" comment:"Overrides the default code.filename_template"`
+	FilenameTemplate        string     `yaml:"filename_template" mapstructure:"filename_template" comment:"Overrides the default code.filename_template, empty will be ignored"`
 	SeparateDescriptionFile bool       `yaml:"separate_description_file,omitempty" mapstructure:"separate_description_file" comment:"Generate question description into a separate file"`
 	Blocks                  []Block    `yaml:"blocks,omitempty" mapstructure:"blocks" comment:"Replace some blocks of the generated code"`
 	Modifiers               []Modifier `yaml:"modifiers,omitempty" mapstructure:"modifiers" comment:"Functions that modify the generated code"`

--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ type CodeConfig struct {
 
 type BaseLangConfig struct {
 	OutDir                  string     `yaml:"out_dir" mapstructure:"out_dir"`
-	FilenameTemplate        string     `yaml:"filename_template" mapstructure:"filename_template" comment:"Overrides the default code.filename_template, empty will be ignored"`
+	FilenameTemplate        string     `yaml:"filename_template,omitempty" mapstructure:"filename_template" comment:"Overrides the default code.filename_template, empty will be ignored"`
 	SeparateDescriptionFile bool       `yaml:"separate_description_file,omitempty" mapstructure:"separate_description_file" comment:"Generate question description into a separate file"`
 	Blocks                  []Block    `yaml:"blocks,omitempty" mapstructure:"blocks" comment:"Replace some blocks of the generated code"`
 	Modifiers               []Modifier `yaml:"modifiers,omitempty" mapstructure:"modifiers" comment:"Functions that modify the generated code"`

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ type ContestConfig struct {
 type Editor struct {
 	Use     string   `yaml:"use" mapstructure:"use" comment:"Use a predefined editor: vim, vscode, goland\nSet to 'none' to disable, set to 'custom' to provide your own command"`
 	Command string   `yaml:"command" mapstructure:"command" comment:"Custom command to open files"`
-	Args    []string `yaml:"args" mapstructure:"args" comment:"Arguments to the command"`
+	Args    []string `yaml:"args" mapstructure:"args" comment:"Arguments to the command.\nString contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}}, {{.AllFiles}} will be replaced with corresponding file path"`
 }
 
 type Block struct {

--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,7 @@ type GoConfig struct {
 
 type PythonConfig struct {
 	BaseLangConfig `yaml:",inline" mapstructure:",squash"`
-	Executable     string `yaml:"executable" mapstructure:"executable" comment:"Python executable to run the generated code"`
+	Executable     string `yaml:"executable" mapstructure:"executable" comment:"Python executable that creates the venv"`
 }
 
 type CppConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ type ContestConfig struct {
 type Editor struct {
 	Use     string   `yaml:"use" mapstructure:"use" comment:"Use a predefined editor: vim, vscode, goland\nSet to 'none' to disable, set to 'custom' to provide your own command"`
 	Command string   `yaml:"command" mapstructure:"command" comment:"Custom command to open files"`
-	Args    []string `yaml:"args" mapstructure:"args" comment:"Arguments to the command.\nString contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}}, {{.AllFiles}} will be replaced with corresponding file path"`
+	Args    []string `yaml:"args" mapstructure:"args" comment:"Arguments to the command.\nString contains {{.CodeFile}}, {{.TestFile}}, {{.DescriptionFile}}, {{.TestCasesFile}} will be replaced with corresponding file path.\n{{.Files}} will be substituted with the list of all file paths."`
 }
 
 type Block struct {

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -1,9 +1,13 @@
 package editor
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
+	"text/template"
 
 	"github.com/charmbracelet/log"
 
@@ -16,28 +20,19 @@ type Opener interface {
 	Open(result *lang.GenerateResult) error
 }
 
-type MultiOpener interface {
-	Opener
-	OpenMulti(result *lang.GenerateResult) error
-}
+const specialAllFiles = "{{.AllFiles}}"
 
-var editors = map[string]Opener{
-	"none":   &noneEditor{},
-	"custom": &customEditor{},
-	"vim": &commonMultiEditor{
-		commonEditor{
-			command: "vim",
-			args:    []string{"-p", fmt.Sprintf("+/%s", constants.CodeBeginMarker)},
-		},
+var knownEditors = map[string]Opener{
+	"none": &noneEditor{},
+	"vim": &editor{
+		command: "vim",
+		args:    []string{"-p", fmt.Sprintf("+/%s", constants.CodeBeginMarker), specialAllFiles},
 	},
-	"neovim": &commonMultiEditor{
-		commonEditor{
-			command: "nvim",
-			args:    []string{"-p", fmt.Sprintf("+/%s", constants.CodeBeginMarker)},
-		},
+	"neovim": &editor{
+		command: "nvim",
+		args:    []string{"-p", fmt.Sprintf("+/%s", constants.CodeBeginMarker), specialAllFiles},
 	},
-	"vscode": &commonMultiEditor{commonEditor{command: "code"}},
-	"goland": &commonEditor{command: "goland"},
+	"vscode": &editor{command: "code", args: []string{specialAllFiles}},
 }
 
 type noneEditor struct{}
@@ -47,51 +42,90 @@ func (e *noneEditor) Open(result *lang.GenerateResult) error {
 	return nil
 }
 
-type commonEditor struct {
+type editor struct {
 	command string
 	args    []string
 }
 
-func (e *commonEditor) Open(result *lang.GenerateResult) error {
-	log.Info("opening file", "command", e.command)
-	return runCmd(e.command, e.args, result.GetFile(lang.CodeFile).GetPath())
-}
-
-type commonMultiEditor struct {
-	commonEditor
-}
-
-func (e *commonMultiEditor) OpenMulti(result *lang.GenerateResult) error {
-	paths := make([]string, 0, len(result.Files))
-	for _, f := range result.Files {
-		paths = append(paths, f.GetPath())
+func (ed *editor) substituteArgs(result *lang.GenerateResult) error {
+	getPath := func(fileType lang.FileType) string {
+		f := result.GetFile(fileType)
+		if f == nil {
+			return ""
+		}
+		return f.GetPath()
 	}
-	log.Info("opening files", "command", e.command)
-	return runCmd(e.command, e.args, paths...)
+
+	const replaceWithAllFiles = "__all_files__"
+	data := struct {
+		AllFiles        string
+		CodeFile        string
+		TestFile        string
+		DescriptionFile string
+		TestCasesFile   string
+	}{
+		AllFiles:        replaceWithAllFiles,
+		CodeFile:        getPath(lang.CodeFile),
+		TestFile:        getPath(lang.TestFile),
+		DescriptionFile: getPath(lang.DocFile),
+		TestCasesFile:   getPath(lang.TestCasesFile),
+	}
+
+	for i, arg := range ed.args {
+		if !strings.Contains(arg, "{{") {
+			continue
+		}
+
+		tmpl := template.New("")
+		_, err := tmpl.Parse(arg)
+		if err != nil {
+			return err
+		}
+		var s bytes.Buffer
+		err = tmpl.Execute(&s, data)
+		if err != nil {
+			return err
+		}
+		ed.args[i] = s.String()
+	}
+
+	// replace the special marker with all files
+	for i, arg := range ed.args {
+		if arg == replaceWithAllFiles {
+			allFiles := make([]string, 0, len(result.Files))
+			for _, f := range result.Files {
+				allFiles = append(allFiles, f.GetPath())
+			}
+			ed.args = append(ed.args[:i], append(allFiles, ed.args[i+1:]...)...)
+			break
+		}
+	}
+
+	return nil
 }
 
-type customEditor struct{}
-
-func (e *customEditor) Open(result *lang.GenerateResult) error {
-	cfg := config.Get()
-	if cfg.Editor.Command == "" {
-		log.Warn("editor.command is empty, skip opening files")
-		return nil
+func (ed *editor) Open(result *lang.GenerateResult) error {
+	err := ed.substituteArgs(result)
+	if err != nil {
+		return fmt.Errorf("invalid editor command: %w", err)
 	}
-	log.Info("opening files", "command", cfg.Editor.Command)
-	return runCmd(cfg.Editor.Command, cfg.Editor.Args, result.GetFile(lang.CodeFile).GetPath())
+	return runCmd(ed.command, ed.args)
 }
 
 func Get(s string) Opener {
-	return editors[s]
+	if s == "custom" {
+		cfg := config.Get()
+		return &editor{
+			command: cfg.Editor.Command,
+			args:    cfg.Editor.Args,
+		}
+	}
+	return knownEditors[s]
 }
 
 func Open(result *lang.GenerateResult) error {
-	if len(result.Files) == 0 {
-		return nil
-	}
 	if result.GetFile(lang.CodeFile) == nil {
-		return fmt.Errorf("no code file found")
+		return errors.New("no code file found, skip opening")
 	}
 
 	cfg := config.Get()
@@ -102,15 +136,14 @@ func Open(result *lang.GenerateResult) error {
 			cfg.Editor.Use,
 		)
 	}
-	if ed, ok := ed.(MultiOpener); ok {
-		return ed.OpenMulti(result)
-	}
 	return ed.Open(result)
 }
 
 func runCmd(command string, args []string, files ...string) error {
 	cmd := exec.Command(command, args...)
 	cmd.Args = append(cmd.Args, files...)
+	log.Info("running command", "command", cmd.Path)
+	log.Debug("command arguments", "arguments", cmd.Args)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -141,9 +141,12 @@ func Open(result *lang.GenerateResult) error {
 
 func runCmd(command string, args []string, files ...string) error {
 	cmd := exec.Command(command, args...)
+	if log.GetLevel() <= log.DebugLevel {
+		log.Info("opening files", "command", cmd.String())
+	} else {
+		log.Info("opening files", "command", cmd.Path)
+	}
 	cmd.Args = append(cmd.Args, files...)
-	log.Info("running command", "command", cmd.Path)
-	log.Debug("command arguments", "arguments", cmd.Args)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Some usage examples:

1. open all files using Goland

```yaml
editor:
  command: open
  args: [ '-a', 'Goland.app', '{{.AllFiles}}' ]
```

2. open files using custom script

```yaml
editor:
  command: /usr/local/bin/opener.sh
  args: ['{{.AllFiles}}' ]
```

/usr/local/bin/opener.sh:

```sh
#!/bin/bash

if [ $# -gt 0 ]; then
    for filepath in "$@"
    do
        file_extension="${filepath##*.}"
        case "$file_extension" in
            md)
                code "$filepath" &
                ;;
            *)
                vim -n "$filepath" &
                ;;
        esac
    done
else
    echo "No file paths provided"
    exit 1
fi
```
