### PR TITLE
fix: failed to start local test in contest

### DIFF
--- a/lang/base.go
+++ b/lang/base.go
@@ -131,7 +131,7 @@ func getFilenameTemplate(q *leetcode.QuestionData, gen Lang) string {
 func getOutDir(q *leetcode.QuestionData, lang Lang) string {
 	cfg := config.Get()
 	if q.IsContest() {
-		return filepath.Join(cfg.ProjectRoot(), config.Get().Contest.OutDir)
+		return filepath.Join(cfg.ProjectRoot(), cfg.Contest.OutDir)
 	}
 	outDir := getCodeStringConfig(lang, "out_dir")
 	// If outDir is not set, use the language slug as the outDir.

--- a/lang/base.go
+++ b/lang/base.go
@@ -128,10 +128,10 @@ func getFilenameTemplate(q *leetcode.QuestionData, gen Lang) string {
 }
 
 func getOutDir(q *leetcode.QuestionData, lang Lang) string {
-	if q.IsContest() {
-		return config.Get().Contest.OutDir
-	}
 	cfg := config.Get()
+	if q.IsContest() {
+		return filepath.Join(cfg.ProjectRoot(), config.Get().Contest.OutDir)
+	}
 	outDir := getCodeStringConfig(lang, "out_dir")
 	// If outDir is not set, use the language slug as the outDir.
 	if outDir == "" {

--- a/lang/base.go
+++ b/lang/base.go
@@ -127,6 +127,7 @@ func getFilenameTemplate(q *leetcode.QuestionData, gen Lang) string {
 	return config.Get().Code.FilenameTemplate
 }
 
+// getOutDir returns the absolute path of the output directory for the question.
 func getOutDir(q *leetcode.QuestionData, lang Lang) string {
 	cfg := config.Get()
 	if q.IsContest() {


### PR DESCRIPTION
When using `leetgo test -L -l python b104/1` for local testing, it will raise `Case 1: Failed to start` error. 

The reason is that python.exe and .py files would return relative paths prefixed with `contest/`, and after [`cmd.Dir = genResult.OutDir`](https://github.com/j178/leetgo/blob/master/lang/test.go#L431) , the file path would change to an error file prefixed with `contest/contest/` path. I think returning the absolute path will solve this problem. 

Tested in Windows 10.