### PR TITLE
feat: support subgroup of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ code:
   lang: go
   # The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}
   # Available attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful
-  # Available functions: lower, upper, trim, padWithZero, toUnderscore
+  # Available functions: lower, upper, trim, padWithZero, toUnderscore, group
   filename_template: '{{ .Id | padWithZero 4 }}{{ if .SlugIsMeaningful }}.{{ .Slug }}{{ end }}'
   # Default setting for separate_description_file
   separate_description_file: true

--- a/README_zh.md
+++ b/README_zh.md
@@ -192,7 +192,7 @@ code:
   lang: go
   # The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}
   # Available attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful
-  # Available functions: lower, upper, trim, padWithZero, toUnderscore
+  # Available functions: lower, upper, trim, padWithZero, toUnderscore, group
   filename_template: '{{ .Id | padWithZero 4 }}{{ if .SlugIsMeaningful }}.{{ .Slug }}{{ end }}'
   # Default setting for separate_description_file
   separate_description_file: true

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,7 @@ type Modifier struct {
 
 type CodeConfig struct {
 	Lang                    string         `yaml:"lang" mapstructure:"lang" comment:"Language of code generated for questions: go, python, ... \n(will be override by project config and flag --lang)"`
-	FilenameTemplate        string         `yaml:"filename_template" mapstructure:"filename_template" comment:"The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}\nAvailable attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful\nAvailable functions: lower, upper, trim, padWithZero, toUnderscore"`
+	FilenameTemplate        string         `yaml:"filename_template" mapstructure:"filename_template" comment:"The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}\nAvailable attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful\nAvailable functions: lower, upper, trim, padWithZero, toUnderscore, group"`
 	SeparateDescriptionFile bool           `yaml:"separate_description_file" mapstructure:"separate_description_file" comment:"Default setting for separate_description_file"`
 	Blocks                  []Block        `yaml:"blocks,omitempty" mapstructure:"blocks" comment:"Default block definitions for all languages"`
 	Modifiers               []Modifier     `yaml:"modifiers,omitempty" mapstructure:"modifiers" comment:"Default modifiers for all languages"`

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/charmbracelet/log v0.2.2
 	github.com/dghubble/sling v1.4.1
 	github.com/dop251/goja v0.0.0-20230216180835-5937a312edda
+	github.com/fatih/color v1.15.0
 	github.com/goccy/go-json v0.10.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/grokify/html-strip-tags-go v0.0.1
@@ -47,7 +48,6 @@ require (
 	github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/dlclark/regexp2 v1.8.0 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect

--- a/leetcode/question.go
+++ b/leetcode/question.go
@@ -585,6 +585,13 @@ func (q *QuestionData) GetFormattedFilename(lang string, filenameTemplate string
 			"toUnderscore": func(s string) string {
 				return strings.ReplaceAll(s, "-", "_")
 			},
+			"group": func(size int, s string) string {
+				id, err := strconv.Atoi(s)
+				if err != nil {
+					return "Others"
+				}
+				return fmt.Sprintf("%d-%d", (id-1)/size*size+1, (id-1)/size*size+size)
+			},
 		},
 	)
 	tmpl, err := tmpl.Parse(filenameTemplate)

--- a/scripts/update_readme.go
+++ b/scripts/update_readme.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/j178/leetgo/cmd"
@@ -38,7 +39,7 @@ func replace(mark string, origin []byte, new []byte) []byte {
 }
 
 func updateUsage(readme []byte) []byte {
-	_ = os.Setenv("NO_COLOR", "true")
+	color.NoColor = true
 	usage := cmd.UsageString()
 	usage = "\n```\n" + usage + "```\n"
 


### PR DESCRIPTION
Add `group` function to `filename_template`, so `filename_template: '{{ group 100 .Id }}/{{ .Id | padWithZero 4 }}{{ if .SlugIsMeaningful }}.{{ .Slug }}{{ end }}'` will generate files within subgroups.
