### PR TITLE
feat: read testcases.txt when running remotely

### DIFF
--- a/lang/gen.go
+++ b/lang/gen.go
@@ -279,3 +279,15 @@ func UpdateSolutionCode(q *leetcode.QuestionData, newCode string) error {
 	log.Info("updated", "file", utils.RelToCwd(codeFile.GetPath()))
 	return nil
 }
+
+func GetTestCases(q *leetcode.QuestionData) (TestCases, error) {
+	result, err := GeneratePathsOnly(q)
+	if err != nil {
+		return TestCases{}, err
+	}
+	testCasesFile := result.GetFile(TestCasesFile)
+	if testCasesFile == nil {
+		return TestCases{}, fmt.Errorf("no test cases file generated")
+	}
+	return ParseTestCases(q, testCasesFile)
+}

--- a/lang/test.go
+++ b/lang/test.go
@@ -153,6 +153,8 @@ type TestCases struct {
 }
 
 func (tc *TestCases) AddCase(c TestCase) {
+	c.No = len(tc.Cases) + 1
+	c.Question = tc.Question
 	tc.Cases = append(tc.Cases, c)
 }
 
@@ -175,6 +177,14 @@ func (tc *TestCases) String() string {
 		if i != len(tc.Cases)-1 {
 			_, _ = fmt.Fprintln(buf)
 		}
+	}
+	return buf.String()
+}
+
+func (tc *TestCases) InputString() string {
+	buf := new(bytes.Buffer)
+	for _, c := range tc.Cases {
+		buf.WriteString(c.InputString())
 	}
 	return buf.String()
 }

--- a/testutils/cpp/stdc++.h
+++ b/testutils/cpp/stdc++.h
@@ -124,7 +124,7 @@
 
 #if __cplusplus >= 201703L
 #include <any>
-#include <charconv>
+// #include <charconv>
 // #include <execution>
 #include <filesystem>
 #include <optional>


### PR DESCRIPTION
Also, remove the way to provide one-shot testcase from command line, since it's very hard to use.

Fixes #222 
