### PR TITLE
adding check for nil test case file

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -117,7 +117,7 @@ func appendToTestCases(q *leetcode.QuestionData, result *leetcode.SubmitCheckRes
 		return false, err
 	}
 	testCasesFile := genResult.GetFile(lang.TestCasesFile)
-	if !utils.IsExist(testCasesFile.GetPath()) {
+	if testCasesFile == nil || !utils.IsExist(testCasesFile.GetPath()) {
 		return false, nil
 	}
 


### PR DESCRIPTION
ran into this error when solution not accepted, fixing it
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10516fd44]

goroutine 1 [running]:
github.com/j178/leetgo/lang.(*FileOutput).GetPath(...)
        github.com/j178/leetgo/lang/base.go:48
github.com/j178/leetgo/cmd.appendToTestCases(0x14000148280, 0x14002358000)
        github.com/j178/leetgo/cmd/submit.go:120 +0xa4
github.com/j178/leetgo/cmd.glob..func17(0x105fa44e0?, {0x1400042ab70, 0x1, 0x105177691?})
        github.com/j178/leetgo/cmd/submit.go:59 +0x31c
github.com/spf13/cobra.(*Command).execute(0x105fa44e0, {0x1400042ab40, 0x1, 0x1})
        github.com/spf13/cobra@v1.7.0/command.go:940 +0x658
github.com/spf13/cobra.(*Command).ExecuteC(0x105fa4200)
        github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.7.0/command.go:992
github.com/j178/leetgo/cmd.Execute()
        github.com/j178/leetgo/cmd/root.go:51 +0x24
main.main()
        github.com/j178/leetgo/main.go:6 +0x1c```