### PR TITLE
feat!: remove global level configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ author: Bob
 # Language of the question description: zh or en
 language: zh
 code:
-  # Language of code generated for questions: go, python, ... 
-  # (will be override by project config and flag --lang)
+  # Language of code generated for questions: go, cpp, python, java... 
+  # (will be overridden by command line flag -l/--lang)
   lang: go
   # The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}
   # Available attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful

--- a/README_zh.md
+++ b/README_zh.md
@@ -193,8 +193,8 @@ author: Bob
 # Language of the question description: zh or en
 language: zh
 code:
-  # Language of code generated for questions: go, python, ... 
-  # (will be override by project config and flag --lang)
+  # Language of code generated for questions: go, cpp, python, java... 
+  # (will be overridden by command line flag -l/--lang)
   lang: go
   # The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}
   # Available attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -55,7 +55,7 @@ var debugCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := config.Get()
 		cwd, _ := os.Getwd()
-		projectConfig, err := os.ReadFile(cfg.ProjectConfigFile())
+		projectConfig, err := os.ReadFile(cfg.ConfigFile())
 		if err != nil {
 			projectConfig = []byte("No project config file found")
 		}
@@ -63,11 +63,10 @@ var debugCmd = &cobra.Command{
 		cmd.Println("```")
 		cmd.Println(buildVersion())
 		cmd.Println("```")
-		cmd.Println("Global config dir    :", cfg.ConfigDir())
-		cmd.Println("Global config file   :", cfg.GlobalConfigFile())
+		cmd.Println("Home dir             :", cfg.HomeDir())
 		cmd.Println("Project root         :", cfg.ProjectRoot())
 		cmd.Println("Working dir          :", cwd)
-		cmd.Println("Project config file  :", cfg.ProjectConfigFile())
+		cmd.Println("Project config file  :", cfg.ConfigFile())
 		cmd.Println("Project configuration:")
 		cmd.Println("```yaml")
 		cmd.Println(string(projectConfig))

--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ type Modifier struct {
 }
 
 type CodeConfig struct {
-	Lang                    string         `yaml:"lang" mapstructure:"lang" comment:"Language of code generated for questions: go, python, ... \n(will be overridden by command line flag -l/--lang)"`
+	Lang                    string         `yaml:"lang" mapstructure:"lang" comment:"Language of code generated for questions: go, cpp, python, java... \n(will be overridden by command line flag -l/--lang)"`
 	FilenameTemplate        string         `yaml:"filename_template" mapstructure:"filename_template" comment:"The default template to generate filename (without extension), e.g. {{.Id}}.{{.Slug}}\nAvailable attributes: Id, Slug, Title, Difficulty, Lang, SlugIsMeaningful\nAvailable functions: lower, upper, trim, padWithZero, toUnderscore, group"`
 	SeparateDescriptionFile bool           `yaml:"separate_description_file" mapstructure:"separate_description_file" comment:"Generate question description into a separate question.md file"`
 	Blocks                  []Block        `yaml:"blocks,omitempty" mapstructure:"blocks" comment:"Default block definitions for all languages"`

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -8,8 +8,7 @@ var (
 
 const (
 	CmdName               = "leetgo"
-	GlobalConfigFilename  = "config.yaml"
-	ProjectConfigFilename = "leetgo.yaml"
+	ConfigFilename        = "leetgo.yaml"
 	QuestionCacheBaseName = "leetcode-questions"
 	StateFilename         = "state.json"
 	CodeBeginMarker       = "@lc code=begin"


### PR DESCRIPTION
Only use `leetgo.yaml` in the project root, no more two-level configurations. The existing global config file will be ignored.