### PR TITLE
Utilize fmt.Stringer interface instead of ToString method

### DIFF
--- a/testutils/go/parse.go
+++ b/testutils/go/parse.go
@@ -157,9 +157,9 @@ func serialize(v reflect.Value) (string, error) {
 	case reflect.Ptr: // *TreeNode, *ListNode
 		switch tpName := v.Type().Elem().Name(); tpName {
 		case "TreeNode":
-			return v.Interface().(*TreeNode).ToString(), nil
+			return v.Interface().(*TreeNode).String(), nil
 		case "ListNode":
-			return v.Interface().(*ListNode).ToString(), nil
+			return v.Interface().(*ListNode).String(), nil
 		default:
 			return "", fmt.Errorf("unknown type %s", tpName)
 		}

--- a/testutils/go/predefined.go
+++ b/testutils/go/predefined.go
@@ -39,9 +39,14 @@ func DeserializeListNode(s string) (*ListNode, error) {
 	return root, nil
 }
 
-// ToString returns a string representation of the linked list.
-// It panics with ErrInfiniteLoop if a cycle is detected.
+// ToString is deprecated, use String()
 func (l *ListNode) ToString() string {
+	return l.String()
+}
+
+// String returns a string representation of the linked list.
+// It panics with ErrInfiniteLoop if a cycle is detected.
+func (l *ListNode) String() string {
 	seen := make(map[*ListNode]bool, 10)
 
 	sb := &strings.Builder{}
@@ -116,9 +121,14 @@ func DeserializeTreeNode(s string) (*TreeNode, error) {
 	return root, nil
 }
 
-// ToString returns a string representation of the binary tree.
-// It panics with ErrInfiniteLoop if a cycle is detected.
+// ToString is deprecated, use String()
 func (t *TreeNode) ToString() string {
+	return t.String()
+}
+
+// String returns a string representation of the binary tree.
+// It panics with ErrInfiniteLoop if a cycle is detected.
+func (t *TreeNode) String() string {
 	nodes := []*TreeNode{}
 	queue := []*TreeNode{t}
 	seen := make(map[*TreeNode]bool, 10)
@@ -184,9 +194,14 @@ func DeserializeNaryTreeNode(s string) (*NaryTreeNode, error) {
 	return root.Children[0], nil
 }
 
-// ToString returns a string representation of the nary tree.
-// It panics with ErrInfiniteLoop if a cycle is detected.
+// ToString is deprecated, use String
 func (t *NaryTreeNode) ToString() string {
+	return t.String()
+}
+
+// String returns a string representation of the nary tree.
+// It panics with ErrInfiniteLoop if a cycle is detected.
+func (t *NaryTreeNode) String() string {
 	nodes := []*NaryTreeNode{}
 	q := []*NaryTreeNode{{Children: []*NaryTreeNode{t}}}
 	seen := make(map[*NaryTreeNode]bool, 10)

--- a/testutils/go/prefdefined_test.go
+++ b/testutils/go/prefdefined_test.go
@@ -77,7 +77,7 @@ func Test_NaryTreeNodeToString(t *testing.T) {
 	for _, test := range tests {
 		t.Run(
 			"", func(t *testing.T) {
-				assert.Equal(t, test.expected, test.tree.ToString())
+				assert.Equal(t, test.expected, test.tree.String())
 			},
 		)
 	}
@@ -94,7 +94,7 @@ func Test_DeserializeNaryTree(t *testing.T) {
 			"", func(t *testing.T) {
 				tree, err := DeserializeNaryTreeNode(test)
 				if assert.NoError(t, err) {
-					assert.Equal(t, test, tree.ToString())
+					assert.Equal(t, test, tree.String())
 				}
 			},
 		)

--- a/testutils/go/serialize_test.go
+++ b/testutils/go/serialize_test.go
@@ -1,6 +1,7 @@
 package goutils
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,17 +18,13 @@ func TestInfiniteLoopDetect(t *testing.T) {
 	naryTree := &NaryTreeNode{Val: 1}
 	naryTree.Children = []*NaryTreeNode{{Val: 2, Children: []*NaryTreeNode{naryTree}}}
 
-	type toStringer interface {
-		ToString() string
-	}
-
-	tests := []toStringer{
+	tests := []fmt.Stringer{
 		linkedList,
 		tree,
 		naryTree,
 	}
 
 	for _, tc := range tests {
-		assert.PanicsWithValue(t, ErrInfiniteLoop, func() { tc.ToString() })
+		assert.PanicsWithValue(t, ErrInfiniteLoop, func() { _ = tc.String() })
 	}
 }


### PR DESCRIPTION
Having a `String()` string method is a more idiomatic way to handle string representation, as implementing the `fmt.Stringer` interface makes it easier to work with the standard library.

https://go.dev/tour/methods/17