### PR TITLE
fix: update to concrete toolchain version go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/j178/leetgo
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Thank you for the updates. 
I do see a warning now though about the toolchain name.
Here are the docs I found
[Go toolchain names](https://go.dev/doc/toolchain#gotoolchainnames)

> Before Go 1.21, the initial release of a Go toolchain was version 1.N, not 1.N.0, so for N < 21, the ordering is adjusted to place 1.N after the release candidates.


`1.22` should to be `1.22.0`

reproduce on `darwin/arm64`.
```sh
$ go version
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```
