### PR TITLE
Add tooling to allow for user-defined post question pick command

### DIFF
--- a/cmd/pick.go
+++ b/cmd/pick.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
 
 	"github.com/j178/leetgo/editor"
@@ -105,7 +106,6 @@ leetgo pick two-sum`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c := leetcode.NewClient(leetcode.ReadCredentials())
 		var q *leetcode.QuestionData
-
 		if len(args) > 0 {
 			qid := args[0]
 			qs, err := leetcode.ParseQID(qid, c)
@@ -135,6 +135,10 @@ leetgo pick two-sum`,
 		result, err := lang.Generate(q)
 		if err != nil {
 			return err
+		}
+
+		if result.PostPickError != "" {
+			log.Error("Post-pick action error: %s\n", result.PostPickError)
 		}
 		if !skipEditor {
 			err = editor.Open(result)

--- a/cmd/pick.go
+++ b/cmd/pick.go
@@ -138,7 +138,7 @@ leetgo pick two-sum`,
 		}
 
 		if result.PostPickError != "" {
-			log.Error("Post-pick action error: %s\n", result.PostPickError)
+			log.Error("error", "post_pick_action", result.PostPickError)
 		}
 		if !skipEditor {
 			err = editor.Open(result)

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,7 @@ type BaseLangConfig struct {
 	SeparateDescriptionFile bool       `yaml:"separate_description_file,omitempty" mapstructure:"separate_description_file" comment:"Generate question description into a separate question.md file, otherwise it will be embed in the code file."`
 	Blocks                  []Block    `yaml:"blocks,omitempty" mapstructure:"blocks" comment:"Replace some blocks of the generated code."`
 	Modifiers               []Modifier `yaml:"modifiers,omitempty" mapstructure:"modifiers" comment:"Functions that modify the generated code."`
+	PostPickAction          string     `yaml:"post_pick_action,omitempty" mapstructure:"post_pick_action" comment: "Run command after picking problem."`
 }
 
 type GoConfig struct {

--- a/lang/base.go
+++ b/lang/base.go
@@ -26,13 +26,14 @@ const (
 const manualWarning = "Warning: this is a manual question, the generated test code may be incorrect."
 
 type GenerateResult struct {
-	mask        int
-	Question    *leetcode.QuestionData
-	Lang        Lang
-	OutDir      string
-	SubDir      string
-	Files       []FileOutput
-	ResultHooks []func(*GenerateResult) error
+	mask          int
+	Question      *leetcode.QuestionData
+	Lang          Lang
+	OutDir        string
+	SubDir        string
+	Files         []FileOutput
+	ResultHooks   []func(*GenerateResult) error
+	PostPickError string
 }
 
 type FileOutput struct {

--- a/lang/cpp.go
+++ b/lang/cpp.go
@@ -2,6 +2,8 @@ package lang
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -382,6 +384,20 @@ func (c cpp) Generate(q *leetcode.QuestionData) (*GenerateResult, error) {
 			return nil, err
 		}
 		genResult.AddFile(docFile)
+	}
+	// Run post-pick action directly.
+	postAction := getCodeStringConfig(c, "post_pick_action")
+	print(postAction)
+	if postAction != "" {
+		parts := strings.Fields(postAction)
+		if len(parts) > 0 {
+			cmd := exec.Command(parts[0], parts[1:]...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return nil, fmt.Errorf("post-pick action failed: %w", err)
+			}
+		}
 	}
 
 	return genResult, nil

--- a/lang/cpp.go
+++ b/lang/cpp.go
@@ -2,8 +2,6 @@ package lang
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -384,20 +382,6 @@ func (c cpp) Generate(q *leetcode.QuestionData) (*GenerateResult, error) {
 			return nil, err
 		}
 		genResult.AddFile(docFile)
-	}
-	// Run post-pick action directly.
-	postAction := getCodeStringConfig(c, "post_pick_action")
-	print(postAction)
-	if postAction != "" {
-		parts := strings.Fields(postAction)
-		if len(parts) > 0 {
-			cmd := exec.Command(parts[0], parts[1:]...)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			if err := cmd.Run(); err != nil {
-				return nil, fmt.Errorf("post-pick action failed: %w", err)
-			}
-		}
 	}
 
 	return genResult, nil

--- a/lang/gen.go
+++ b/lang/gen.go
@@ -1,10 +1,13 @@
 package lang
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
+	"text/template"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -105,6 +108,41 @@ func generate(q *leetcode.QuestionData) (Lang, *GenerateResult, error) {
 		}
 		result.Files[i].Written = written
 	}
+
+	// Execute post-pick action after file writes
+	postAction := getCodeStringConfig(gen, "post_pick_action")
+	if postAction != "" {
+		// Build the substitution context.
+		data := struct {
+			Folder string
+		}{
+			Folder: result.TargetDir(),
+		}
+		// Parse and execute the template.
+		tmpl, err := template.New("postPick").Parse(postAction)
+		if err != nil {
+			result.PostPickError = fmt.Sprintf("post-pick action template parsing failed: %v", err)
+		} else {
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, data); err != nil {
+				result.PostPickError = fmt.Sprintf("post-pick action template execution failed: %v", err)
+			} else {
+				substitutedCommand := buf.String()
+				// Split the substituted command into parts.
+				parts := strings.Fields(substitutedCommand)
+				if len(parts) > 0 {
+					log.Info("executing", "post_pick_action", substitutedCommand)
+					cmd := exec.Command(parts[0], parts[1:]...)
+					cmd.Stdout = os.Stdout
+					cmd.Stderr = os.Stderr
+					if err := cmd.Run(); err != nil {
+						result.PostPickError = fmt.Sprintf("post-pick action failed: %v", err)
+					}
+				}
+			}
+		}
+	}
+
 	return gen, result, nil
 }
 

--- a/lang/gen.go
+++ b/lang/gen.go
@@ -136,7 +136,7 @@ func generate(q *leetcode.QuestionData) (Lang, *GenerateResult, error) {
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr
 					if err := cmd.Run(); err != nil {
-						result.PostPickError = fmt.Sprintf("post-pick action failed: %v", err)
+						result.PostPickError = fmt.Sprintf("%v", err)
 					}
 				}
 			}


### PR DESCRIPTION
For CPP files, I found that I needed an extra file in my code folder to prevent my editor's code anaylsis from throwing spurious warnings.
It makes sense to copy this file into the code folder after every pick action, and it also makes sense to not have this hard-coded since other people's dev environments may be different.
Therefore, this PR allows a user to set thier own default action to take after a pick action has been completed.

I'm happy to make any edits to this or to have this thrown out - it's my first bit of Go code and I'm not sure if this even warrants a feature request.

For context, I'm using this to push build commands and a test framework to each problem so I can do a build and test on a given problem's tests in vim directly.
