### PR TITLE
chore: update brew installation to use core tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can download the latest binary from the [release page](https://github.com/j1
 ### Install via [HomeBrew](https://brew.sh/) on macOS/Linux
 
 ```shell
-brew install --cask j178/tap/leetgo
+brew install leetgo
 ```
 
 ### Install via [Scoop](https://scoop.sh/) on Windows

--- a/README_zh.md
+++ b/README_zh.md
@@ -109,7 +109,7 @@ func main() {
 ### macOS/Linux 使用 [HomeBrew](https://brew.sh/)
 
 ```shell
-brew install --cask j178/tap/leetgo
+brew install leetgo
 ```
 
 ### Windows 使用 [Scoop](https://scoop.sh/)


### PR DESCRIPTION
chore: update brew installation to use core tap

- https://github.com/Homebrew/homebrew-core/pull/215873