### PR TITLE
Prevent panic on empty array in the Rust test utility

### DIFF
--- a/testutils/rust/src/tree.rs
+++ b/testutils/rust/src/tree.rs
@@ -107,7 +107,7 @@ impl<'de> serde::de::Visitor<'de> for BinaryTreeVisitor {
             }))));
         }
 
-        let root = nodes[0].clone();
+        let root = nodes.first().cloned().flatten();
         let (mut i, mut j) = (0, 1);
 
         while j < nodes.len() {


### PR DESCRIPTION
This was causing a runtime error when the input was an empty array.