### PR TITLE
fix(cpp): reject input a scan loop cannot make progress on

### DIFF
--- a/testutils/cpp/LC_IO.h
+++ b/testutils/cpp/LC_IO.h
@@ -1,7 +1,9 @@
 #ifndef LC_IO_H
 #define LC_IO_H
 
+#include <cstdlib>
 #include <iomanip>
+#include <iostream>
 #include <queue>
 
 /**
@@ -29,6 +31,25 @@ struct TreeNode {
 namespace LeetCodeIO {
     namespace Helper {
         /**
+         * Function for rejecting input a scan loop cannot make progress on.
+         *
+         * Each loop below dispatches on is.peek() and, in its default branch,
+         * extracts with operator>>. A failed extraction consumes nothing, so
+         * peek() returns the same byte forever: truncated input such as
+         * "[1,2,3" spins without terminating, allocating on every pass. The
+         * loops end only on ']', which malformed input never supplies.
+         *
+         * Called at the top of every loop, this converts that hang into an
+         * immediate diagnostic. Valid input never reaches it in a failed state,
+         * because a well-formed array always has a ']' left to consume.
+         */
+        inline void require_progress(std::istream &is, const char *what) {
+            if (is && is.peek() != std::char_traits<char>::eof()) { return; }
+            std::cerr << "LC_IO: malformed or truncated input while reading " << what << '\n';
+            std::exit(2);
+        }
+
+        /**
          * Function for deserializing a singly-linked list.
          */
         inline void scan_list(std::istream &is, ListNode *&node) {
@@ -36,7 +57,8 @@ namespace LeetCodeIO {
             ListNode *now = nullptr;
         [[maybe_unused]]
         L0: is.ignore();
-        L1: switch (is.peek()) {
+        L1: require_progress(is, "a list");
+            switch (is.peek()) {
             case ' ':
             case ',': is.ignore(); goto L1;
             case ']': is.ignore(); goto L2;
@@ -54,7 +76,8 @@ namespace LeetCodeIO {
             std::deque<TreeNode *> dq;
         [[maybe_unused]]
         L0: is.ignore();
-        L1: switch (is.peek()) {
+        L1: require_progress(is, "a tree");
+            switch (is.peek()) {
             case ' ':
             case ',': is.ignore(); goto L1;
             case 'n': is.ignore(4); dq.emplace_back(nullptr);
@@ -156,7 +179,8 @@ namespace LeetCodeIO {
     [[maybe_unused]]
     L0: is >> std::ws;
         is.ignore();
-    L1: switch (is.peek()) {
+    L1: Helper::require_progress(is, "an array");
+        switch (is.peek()) {
         case ' ':
         case ',': is.ignore(); goto L1;
         case ']': is.ignore(); goto L2;


### PR DESCRIPTION
### Problem

The three scan loops in `testutils/cpp/LC_IO.h` hang forever on malformed or truncated input.

Each loop dispatches on `is.peek()` and, in its `default:` branch, extracts with `operator>>`. A failed extraction consumes nothing, so `peek()` returns the same byte on the next pass. The loops terminate only on `']'`, which malformed input never supplies — so the loop spins, allocating on every iteration.

Standalone reproducer, no leetgo workspace needed:

```cpp
#include <sstream>
#include <vector>
#include "../LC_IO.h"

int main() {
    std::stringstream in("[1,2,3");  // truncated: no closing bracket
    std::vector<int> v;
    LeetCodeIO::scan(in, v);         // never returns
}
```

`Helper::scan_list` and `Helper::scan_tree` have the identical structure and the identical behaviour. `[1,null,3]` scanned as `vector<int>` hangs the same way, since `n` fails extraction in the array loop.

### Fix

`require_progress()` checks at the top of each loop and exits with a diagnostic instead of spinning.

Three loops is complete coverage rather than partial: the scalar `scan` overloads either delegate to these loops or use `>>` / `std::quoted`, whose failures set failbit and surface at the enclosing loop's next check.

The check cannot fire on valid input — a well-formed array always has a `']'` left to consume, and the trailing `cin.ignore()` calls in generated drivers run after the loop has already returned.

### Why it is worth fixing

Beyond the hang itself, this is currently mis-reported. `leetgo test` shows malformed input as a three-second **time limit exceeded**, which sends users looking for a performance problem that does not exist. It also makes a gen/brute stress loop wedge silently, since a generator bug produces exactly this input.

### Notes

- Includes `<cstdlib>` and `<iostream>` explicitly rather than relying on `<bits/stdc++.h>` being pulled in first by generated code.
- Verified with the CI command (`g++ -std=c++17 -O2 -o tests tests.cpp && ./tests`): all 15 existing tests pass.
- No test added — exercising this kills the process, and `tests/tests.cpp` is single-process with no death-test facility. Happy to add a `fork()`-based test, or to switch the failure to a throw so it can be caught in-process, if you would prefer either.
