### PR TITLE
feat(cpp): add the default TreeNode constructor

### DIFF
--- a/testutils/cpp/LC_IO.h
+++ b/testutils/cpp/LC_IO.h
@@ -22,6 +22,7 @@ struct TreeNode {
     int val;
     TreeNode *left;
     TreeNode *right;
+    TreeNode() : val(0), left(nullptr), right(nullptr) {}
     TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
     TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
 };


### PR DESCRIPTION
### Problem

LeetCode's own C++ boilerplate for tree problems declares the no-argument constructor:

```cpp
struct TreeNode {
    int val;
    TreeNode *left;
    TreeNode *right;
    TreeNode() : val(0), left(nullptr), right(nullptr) {}
    TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
    TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
};
```

`testutils/cpp/LC_IO.h` declares only the latter two. So a solution that calls `new TreeNode()` — common in tree-building and serialize/deserialize problems — compiles on the judge and fails to compile locally:

```
error: no matching function for call to 'TreeNode::TreeNode()'
```

That is the exact case local testing exists to catch, and here it produces a false negative against code the judge accepts.

`ListNode` in this same header already carries the matching set of three, which makes the asymmetry easy to miss until a tree problem runs into it.

### Change

One line, restoring parity with both LeetCode's boilerplate and `ListNode`.

Verified with the CI command (`g++ -std=c++17 -O2 -o tests tests.cpp && ./tests`): all 15 existing tests pass.

Filed separately from #418 so the two can be judged on their own merits — that one is a bug fix, this one touches a public struct's API.
